### PR TITLE
Update package.json to support React 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "@mui/material": "^5.3.0",
     "markdown-to-jsx": "^7.1.6",
     "prism-react-renderer": "^1.2.1",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": ">= 17.0.2",
+    "react-dom": ">= 17.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.16.12",


### PR DESCRIPTION
Hello, I haven't done any extensive testing but does react 17 need to be a peer dependency? At the very least, can it be the minimum version instead of the required one? Thanks :)