### PR TITLE
Improve documentation for Syntax Highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Props available for `MuiMarkdown` component:
 | themes            | HighlightThemes         | -                | **optional**          |
 | hideLineNumbers   | boolean                 | false            | **optional**          |
 
-Note: You cannot use overrides and options at the same time.
+> **NOTE:** You cannot use overrides and options at the same time.
 
 ### overrides
 
@@ -268,6 +268,34 @@ const App = () => {
       themes={themes}
       prismTheme={themes.github}
       hideLineNumbers
+    >
+      {`# Hello markdown!`}
+    </MuiMarkdown>
+  );
+};
+
+export default App;
+```
+
+If you want to use Syntax Highlight with `options` then pass `Highlight`, `themes` and `themes.github` in `getOverrides` function.
+
+```tsx
+import React from 'react';
+import { MuiMarkdown, getOverrides } from 'mui-markdown';
+import { Highlight, themes } from 'prism-react-renderer';
+
+const App = () => {
+  return (
+    <MuiMarkdown
+      overrides={{
+        ...getOverrides({ Highlight, themes, theme: themes.github }), // This will keep the other default overrides.
+        h1: {
+          component: "p",
+          props: {
+            style: { color: "red" },
+          },
+        },
+      }}
     >
       {`# Hello markdown!`}
     </MuiMarkdown>

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Props available for `MuiMarkdown` component:
 | themes            | HighlightThemes         | -                | **optional**          |
 | hideLineNumbers   | boolean                 | false            | **optional**          |
 
-> **NOTE:** You cannot use overrides and options at the same time.
+**NOTE:** You cannot use overrides and options at the same time.
 
 ### overrides
 
@@ -277,7 +277,7 @@ const App = () => {
 export default App;
 ```
 
-If you want to use Syntax Highlight with `options` then pass `Highlight`, `themes` and `themes.github` in `getOverrides` function.
+When you use overrides, you can have the syntax highlight by passing the `Highlight`, `themes`, and `themes.github` (or your favorite one) to the `getOverrides` function.
 
 ```tsx
 import React from 'react';


### PR DESCRIPTION
This is an improvement suggested in #17 .

It highlights Note about overrides and options incompatibility in the documentation. Also, it adds an example of how to use Syntax Highlights with `options`.