### PR TITLE
fix: table responsiveness

### DIFF
--- a/package/src/components/TableWrapper.tsx
+++ b/package/src/components/TableWrapper.tsx
@@ -22,7 +22,9 @@ const TableWrapper = (props: TableProps) => {
             })
       }
     >
-      <Table {...otherProps}>{children}</Table>
+      <Box sx={{ width: "100%", display: "table", tableLayout: "fixed" }}>
+        <Table {...otherProps}>{children}</Table>
+      </Box>
     </Box>
   );
 };


### PR DESCRIPTION
Add second Box component inside TableWrapper for better table responsiveness. Previously, on small view ports the Table would not squeeze in with the rest of the elements, and would cause the entire page to have a horizontal scroll instead of the table. Now, the Table gets its own scroll on smaller view ports, maintaining the coherence of the page. 